### PR TITLE
updated URL for libssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
     libxt-dev
 
 # Download and install libssl 0.9.8
-RUN wget --no-verbose http://ftp.us.debian.org/debian/pool/main/o/openssl/libssl0.9.8_0.9.8o-4squeeze14_amd64.deb && \
+RUN wget --no-verbose http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl0.9.8_0.9.8o-4squeeze14_amd64.deb && \
     dpkg -i libssl0.9.8_0.9.8o-4squeeze14_amd64.deb && \
     rm -f libssl0.9.8_0.9.8o-4squeeze14_amd64.deb
 


### PR DESCRIPTION
Old address for this version of libssl was not responding for me. 
